### PR TITLE
Use current syntax for interpolation

### DIFF
--- a/Zig/factorial.zig
+++ b/Zig/factorial.zig
@@ -6,7 +6,7 @@ fn factorial(n: i32) i32 {
 }
 
 pub fn main() void {
-    warn("{}\n", factorial(1)); // 1
-    warn("{}\n", factorial(5)); // 120
-    warn("{}\n", factorial(7)); // 5040
+    warn("{}\n", .{factorial(1)}); // 1
+    warn("{}\n", .{factorial(5)}); // 120
+    warn("{}\n", .{factorial(7)}); // 5040
 }


### PR DESCRIPTION
Change `warn("{}\n", factorial(1));` to `warn("{}\n", .{factorial(1)});` so that the program successfully compiles under current master Zig. A dot and curly braces are added around the function call.